### PR TITLE
Add a mattermost push proxy service to RiffEDU docker stack (RA-586)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,14 @@ services:
       - edu-mm
       - edu-riffdata
 
+  edu-mpns:
+    image: 'mattermost/mattermost-push-proxy:5.23.0'
+    ports:
+      - '8066:8066'
+    volumes:
+      - edu-mpns-config:/mattermost-push-proxy/config
+      - edu-mpns-certs:/mattermost-push-proxy/certs
+
   edu-riffdata-db:
     image: mongo:${MONGO_VER-latest}
     volumes:
@@ -52,3 +60,5 @@ volumes:
   edu-riffdata-db-data:
   edu-riffdata-db-configdb:
   edu-mm-db-data:
+  edu-mpns-config:
+  edu-mpns-certs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
     image: 'mattermost/mattermost-push-proxy:5.23.0'
     ports:
       - '8066:8066'
+    logging:
+        driver: json-file
+        options:
+            max-file: 4
+            max-size: '5m'
     volumes:
       - edu-mpns-config:/mattermost-push-proxy/config
       - edu-mpns-certs:/mattermost-push-proxy/certs

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -42,6 +42,18 @@ services:
       placement:
         constraints: [node.labels.web == true]
 
+  edu-mpns:
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+    configs:
+      - source: riffedu.mattermost-push-proxy.json
+        target: /mattermost-push-proxy/config/mattermost-push-proxy.json
+      - source: apple-push-cert.pem
+        target: /mattermost-push-proxy/certs/apple-push-cert.pem
+
   edu-riffdata-db:
     deploy:
       replicas: 1
@@ -62,4 +74,8 @@ services:
 
 configs:
   riffdata.local-production.yml.1:
+    external: true
+  riffedu.mattermost-push-proxy.json:
+    external: true
+  apple-push-cert.pem:
     external: true

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -51,8 +51,9 @@ services:
     configs:
       - source: riffedu.mattermost-push-proxy.json
         target: /mattermost-push-proxy/config/mattermost-push-proxy.json
-      - source: apple-push-cert.pem
-        target: /mattermost-push-proxy/certs/apple-push-cert.pem
+    secrets:
+      - source: riffedu.apple-push-cert.pem
+        target: riffedu.apple-push-cert.pem
 
   edu-riffdata-db:
     deploy:
@@ -77,5 +78,7 @@ configs:
     external: true
   riffedu.mattermost-push-proxy.json:
     external: true
-  apple-push-cert.pem:
+
+secrets:
+  riffedu.apple-push-cert.pem:
     external: true


### PR DESCRIPTION
## Description

Added a service to the RiffEDU docker stack `edu-mpns` set up with a config and a secret:
- config `riffedu.mattermost-push-proxy.json` is mapped to `/mattermost-push-proxy/config/mattermost-push-proxy.json`
- secret `apple-push-cert.pem` should be reference in the config at `/run/secrets/apple-push-cert.pem`

To use this notification server the RiffEDU system console _ENVIRONMENT | Push Notification Server | Push Notification Server_ field should be set to `http://edu-mpns:8066`